### PR TITLE
Containerfile: make image smaller

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -5,7 +5,7 @@ COPY go.mod go.sum ./
 RUN go mod download
 
 COPY . .
-RUN CGO_ENABLED=0 GOOS=linux go build -o /icinga-kubernetes cmd/icinga-kubernetes/main.go
+RUN CGO_ENABLED=0 GOOS=linux go build -ldflags '-s -w' -o /icinga-kubernetes cmd/icinga-kubernetes/main.go
 
 FROM scratch
 


### PR DESCRIPTION
by omitting unnecessary debug info.

    $ go tool link
    ...
      -s    disable symbol table
    ...
      -w    disable DWARF generation
    $