### PR TITLE
Update schema.sql

### DIFF
--- a/schema/mysql/schema.sql
+++ b/schema/mysql/schema.sql
@@ -1,7 +1,7 @@
 CREATE TABLE annotation (
   uuid binary(16) NOT NULL,
   name varchar(63) COLLATE utf8mb4_unicode_ci NOT NULL,
-  value mediumblob COLLATE utf8mb4_unicode_ci NOT NULL,
+  value mediumblob NOT NULL,
   PRIMARY KEY (uuid)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin;
 


### PR DESCRIPTION
The error (COLLATION 'utf8mb4_unicode_ci' is not valid for CHARACTER SET 'binary') occurs because MySQL doesn't allow a collation like utf8mb4_unicode_ci to be used with columns that have the binary character set. This is because binary is a special character set that treats data as raw bytes, and collation doesn't make sense for raw binary data.

Column defined as mediumblob with COLLATE utf8mb4_unicode_ci, which is the root cause of the issue. BLOB (Binary Large Object) data types don't support collations because they are meant to store binary data (i.e., raw bytes), which is not interpreted as text.

fixes #98