### PR TITLE
Fix icinga states

### DIFF
--- a/pkg/schema/v1/contracts.go
+++ b/pkg/schema/v1/contracts.go
@@ -7,9 +7,7 @@ import (
 	"github.com/icinga/icinga-go-library/types"
 	kmetav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	ktypes "k8s.io/apimachinery/pkg/types"
-	kcache "k8s.io/client-go/tools/cache"
 	"reflect"
-	"time"
 )
 
 var NameSpaceKubernetes = uuid.MustParse("3f249403-2bb0-428f-8e91-504d1fd7ddb6")
@@ -116,25 +114,6 @@ func NewNullableString(s any) sql.NullString {
 	}
 
 	panic(fmt.Sprintf("invalid type %T", s))
-}
-
-func IsWithinGracePeriod(k kmetav1.Object) *string {
-	const gracePeriod = 5 * time.Minute
-
-	deadline := k.GetCreationTimestamp().Add(gracePeriod)
-	now := time.Now()
-	if now.Before(deadline) {
-		key, _ := kcache.MetaNamespaceKeyFunc(k)
-		reason := fmt.Sprintf(
-			"%s %s is within grace period until %s, so its state is not yet evaluated.",
-			types.Name(k),
-			key,
-			deadline)
-
-		return &reason
-	}
-
-	return nil
 }
 
 // Assert interface compliance.

--- a/pkg/schema/v1/daemon_set.go
+++ b/pkg/schema/v1/daemon_set.go
@@ -161,10 +161,6 @@ func (d *DaemonSet) getIcingaState() (IcingaState, string) {
 		return Unknown, reason
 	}
 
-	if gracePeriodReason := IsWithinGracePeriod(d); gracePeriodReason != nil {
-		return Ok, *gracePeriodReason
-	}
-
 	switch {
 	case d.NumberAvailable == 0:
 		reason := fmt.Sprintf("DaemonSet %s/%s does not have a single pod available which should run on %d desired nodes.", d.Namespace, d.Name, d.DesiredNumberScheduled)

--- a/pkg/schema/v1/deployment.go
+++ b/pkg/schema/v1/deployment.go
@@ -167,10 +167,6 @@ func (d *Deployment) Obtain(k8s kmetav1.Object) {
 }
 
 func (d *Deployment) getIcingaState() (IcingaState, string) {
-	if gracePeriodReason := IsWithinGracePeriod(d); gracePeriodReason != nil {
-		return Ok, *gracePeriodReason
-	}
-
 	for _, condition := range d.Conditions {
 		if condition.Type == string(kappsv1.DeploymentAvailable) && condition.Status != string(kcorev1.ConditionTrue) {
 			reason := fmt.Sprintf("Deployment %s/%s is not available: %s.", d.Namespace, d.Name, condition.Message)

--- a/pkg/schema/v1/replica_set.go
+++ b/pkg/schema/v1/replica_set.go
@@ -154,10 +154,6 @@ func (r *ReplicaSet) Obtain(k8s kmetav1.Object) {
 }
 
 func (r *ReplicaSet) getIcingaState() (IcingaState, string) {
-	if gracePeriodReason := IsWithinGracePeriod(r); gracePeriodReason != nil {
-		return Ok, *gracePeriodReason
-	}
-
 	for _, condition := range r.Conditions {
 		if condition.Type == string(kappsv1.ReplicaSetReplicaFailure) && condition.Status == string(kcorev1.ConditionTrue) {
 			reason := fmt.Sprintf("ReplicaSet %s/%s has a failure condition: %s.", r.Namespace, r.Name, condition.Message)

--- a/pkg/schema/v1/replica_set.go
+++ b/pkg/schema/v1/replica_set.go
@@ -154,12 +154,6 @@ func (r *ReplicaSet) Obtain(k8s kmetav1.Object) {
 }
 
 func (r *ReplicaSet) getIcingaState() (IcingaState, string) {
-	if r.DesiredReplicas < 1 {
-		reason := fmt.Sprintf("ReplicaSet %s/%s has an invalid desired replica count: %d.", r.Namespace, r.Name, r.DesiredReplicas)
-
-		return Unknown, reason
-	}
-
 	if gracePeriodReason := IsWithinGracePeriod(r); gracePeriodReason != nil {
 		return Ok, *gracePeriodReason
 	}
@@ -173,7 +167,7 @@ func (r *ReplicaSet) getIcingaState() (IcingaState, string) {
 	}
 
 	switch {
-	case r.AvailableReplicas < 1:
+	case r.AvailableReplicas < 1 && r.DesiredReplicas > 0:
 		reason := fmt.Sprintf("ReplicaSet %s/%s has no replica available from %d desired.", r.Namespace, r.Name, r.DesiredReplicas)
 
 		return Critical, reason

--- a/pkg/schema/v1/stateful_set.go
+++ b/pkg/schema/v1/stateful_set.go
@@ -179,10 +179,6 @@ func (s *StatefulSet) Obtain(k8s kmetav1.Object) {
 }
 
 func (s *StatefulSet) getIcingaState() (IcingaState, string) {
-	if gracePeriodReason := IsWithinGracePeriod(s); gracePeriodReason != nil {
-		return Ok, *gracePeriodReason
-	}
-
 	switch {
 	case s.AvailableReplicas == 0:
 		reason := fmt.Sprintf("StatefulSet %s/%s has no replica available from %d desired.", s.Namespace, s.Name, s.DesiredReplicas)


### PR DESCRIPTION
This PR introduces the following changes:

* Remove the grace period as it is unreliable. Each grace period would require a timer to clear the condition.
* Treat replica set with `0` desired replicas as `ok`.

fixes Icinga/icinga-kubernetes-web#57
fixes Icinga/icinga-kubernetes-web#58
fixes Icinga/icinga-kubernetes-web#63