### PR TITLE
Fix schema: length of column name of annotation

### DIFF
--- a/schema/mysql/schema.sql
+++ b/schema/mysql/schema.sql
@@ -1,6 +1,6 @@
 CREATE TABLE annotation (
   uuid binary(16) NOT NULL,
-  name varchar(63) COLLATE utf8mb4_unicode_ci NOT NULL,
+  name varchar(255) COLLATE utf8mb4_unicode_ci NOT NULL,
   value mediumblob NOT NULL,
   PRIMARY KEY (uuid)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin;


### PR DESCRIPTION
The length of the column 'name' from the table 'annotation' appears to be too short, the Daemon throws following error:

```
$ go run cmd/icinga-kubernetes/main.go
I1128 11:53:15.948638  440210 main.go:72] Starting Icinga for Kubernetes (0.2.0)
I1128 11:53:15.952259  440210 database.go:285] "Connecting to database" logger="database"
F1128 11:53:16.358382  440210 main.go:523] can't retry: can't perform "INSERT INTO `annotation` (`value`, `uuid`, `name`) VALUES (:value, :uuid, :name) ON DUPLICATE KEY UPDATE `value` = VALUES(`value`), `uuid` = VALUES(`uuid`), `name` = VALUES(`name`)": Error 1406 (22001): Data too long for column 'name' at row 11
exit status 255
```