### PR TITLE
Favorites feature

### DIFF
--- a/pkg/schema/v1/cron_job.go
+++ b/pkg/schema/v1/cron_job.go
@@ -31,6 +31,7 @@ type CronJob struct {
 	Annotations                []Annotation         `db:"-"`
 	CronJobAnnotations         []CronJobAnnotation  `db:"-"`
 	ResourceAnnotations        []ResourceAnnotation `db:"-"`
+	Favorites                  []Favorite           `db:"-"`
 }
 
 type CronJobLabel struct {
@@ -129,5 +130,6 @@ func (c *CronJob) Relations() []database.Relation {
 		database.HasMany(c.ResourceAnnotations, database.WithForeignKey("resource_uuid")),
 		database.HasMany(c.Annotations, database.WithoutCascadeDelete()),
 		database.HasMany(c.CronJobAnnotations, fk),
+		database.HasMany(c.Favorites, database.WithForeignKey("resource_uuid")),
 	}
 }

--- a/pkg/schema/v1/daemon_set.go
+++ b/pkg/schema/v1/daemon_set.go
@@ -38,6 +38,7 @@ type DaemonSet struct {
 	Annotations            []Annotation          `db:"-"`
 	DaemonSetAnnotations   []DaemonSetAnnotation `db:"-"`
 	ResourceAnnotations    []ResourceAnnotation  `db:"-"`
+	Favorites              []Favorite            `db:"-"`
 }
 
 type DaemonSetCondition struct {
@@ -216,5 +217,6 @@ func (d *DaemonSet) Relations() []database.Relation {
 		database.HasMany(d.ResourceAnnotations, database.WithForeignKey("resource_uuid")),
 		database.HasMany(d.Annotations, database.WithoutCascadeDelete()),
 		database.HasMany(d.DaemonSetAnnotations, fk),
+		database.HasMany(d.Favorites, database.WithForeignKey("resource_uuid")),
 	}
 }

--- a/pkg/schema/v1/deployment.go
+++ b/pkg/schema/v1/deployment.go
@@ -40,6 +40,7 @@ type Deployment struct {
 	Annotations             []Annotation           `db:"-"`
 	DeploymentAnnotations   []DeploymentAnnotation `db:"-"`
 	ResourceAnnotations     []ResourceAnnotation   `db:"-"`
+	Favorites               []Favorite             `db:"-"`
 }
 
 type DeploymentCondition struct {
@@ -235,5 +236,6 @@ func (d *Deployment) Relations() []database.Relation {
 		database.HasMany(d.ResourceAnnotations, database.WithForeignKey("resource_uuid")),
 		database.HasMany(d.Annotations, database.WithoutCascadeDelete()),
 		database.HasMany(d.DeploymentAnnotations, fk),
+		database.HasMany(d.Favorites, database.WithForeignKey("resource_uuid")),
 	}
 }

--- a/pkg/schema/v1/favorite.go
+++ b/pkg/schema/v1/favorite.go
@@ -6,4 +6,5 @@ type Favorite struct {
 	ResourceUuid types.UUID
 	Kind         string
 	Username     string
+	Priority     int
 }

--- a/pkg/schema/v1/favorite.go
+++ b/pkg/schema/v1/favorite.go
@@ -4,5 +4,6 @@ import "github.com/icinga/icinga-go-library/types"
 
 type Favorite struct {
 	ResourceUuid types.UUID
+	Kind         string
 	Username     string
 }

--- a/pkg/schema/v1/favorite.go
+++ b/pkg/schema/v1/favorite.go
@@ -1,0 +1,8 @@
+package v1
+
+import "github.com/icinga/icinga-go-library/types"
+
+type Favorite struct {
+	ResourceUuid types.UUID
+	Username     string
+}

--- a/pkg/schema/v1/ingress.go
+++ b/pkg/schema/v1/ingress.go
@@ -25,6 +25,7 @@ type Ingress struct {
 	Annotations            []Annotation             `db:"-"`
 	IngressAnnotations     []IngressAnnotation      `db:"-"`
 	ResourceAnnotations    []ResourceAnnotation     `db:"-"`
+	Favorites              []Favorite               `db:"-"`
 }
 
 type IngressTls struct {
@@ -228,5 +229,6 @@ func (i *Ingress) Relations() []database.Relation {
 		database.HasMany(i.ResourceAnnotations, database.WithForeignKey("resource_uuid")),
 		database.HasMany(i.Annotations, database.WithoutCascadeDelete()),
 		database.HasMany(i.IngressAnnotations, fk),
+		database.HasMany(i.Favorites, database.WithForeignKey("resource_uuid")),
 	}
 }

--- a/pkg/schema/v1/job.go
+++ b/pkg/schema/v1/job.go
@@ -41,6 +41,7 @@ type Job struct {
 	JobAnnotations          []JobAnnotation      `db:"-"`
 	ResourceAnnotations     []ResourceAnnotation `db:"-"`
 	Owners                  []JobOwner           `db:"-"`
+	Favorites               []Favorite           `db:"-"`
 }
 
 type JobCondition struct {
@@ -287,5 +288,6 @@ func (j *Job) Relations() []database.Relation {
 		database.HasMany(j.Annotations, database.WithoutCascadeDelete()),
 		database.HasMany(j.JobAnnotations, fk),
 		database.HasMany(j.Owners, fk),
+		database.HasMany(j.Favorites, database.WithForeignKey("resource_uuid")),
 	}
 }

--- a/pkg/schema/v1/namespace.go
+++ b/pkg/schema/v1/namespace.go
@@ -22,6 +22,7 @@ type Namespace struct {
 	Annotations          []Annotation          `db:"-"`
 	NamespaceAnnotations []NamespaceAnnotation `db:"-"`
 	ResourceAnnotations  []ResourceAnnotation  `db:"-"`
+	Favorites            []Favorite            `db:"-"`
 }
 
 type NamespaceCondition struct {
@@ -117,5 +118,6 @@ func (n *Namespace) Relations() []database.Relation {
 		database.HasMany(n.ResourceAnnotations, database.WithForeignKey("resource_uuid")),
 		database.HasMany(n.Annotations, database.WithoutCascadeDelete()),
 		database.HasMany(n.NamespaceAnnotations, fk),
+		database.HasMany(n.Favorites, database.WithForeignKey("resource_uuid")),
 	}
 }

--- a/pkg/schema/v1/node.go
+++ b/pkg/schema/v1/node.go
@@ -50,6 +50,7 @@ type Node struct {
 	Annotations             []Annotation         `db:"-"`
 	NodeAnnotations         []NodeAnnotation     `db:"-"`
 	ResourceAnnotations     []ResourceAnnotation `db:"-"`
+	Favorites               []Favorite           `db:"-"`
 }
 
 type NodeCondition struct {
@@ -282,6 +283,7 @@ func (n *Node) Relations() []database.Relation {
 		database.HasMany(n.ResourceAnnotations, database.WithForeignKey("resource_uuid")),
 		database.HasMany(n.Annotations, database.WithoutCascadeDelete()),
 		database.HasMany(n.NodeAnnotations, fk),
+		database.HasMany(n.Favorites, database.WithForeignKey("resource_uuid")),
 	}
 }
 

--- a/pkg/schema/v1/persistent_volume.go
+++ b/pkg/schema/v1/persistent_volume.go
@@ -33,6 +33,7 @@ type PersistentVolume struct {
 	Annotations                 []Annotation                 `db:"-"`
 	PersistentVolumeAnnotations []PersistentVolumeAnnotation `db:"-"`
 	ResourceAnnotations         []PersistentVolumeAnnotation `db:"-"`
+	Favorites                   []Favorite                   `db:"-"`
 }
 
 type PersistentVolumeClaimRef struct {
@@ -147,5 +148,6 @@ func (p *PersistentVolume) Relations() []database.Relation {
 		database.HasMany(p.ResourceAnnotations, database.WithForeignKey("resource_uuid")),
 		database.HasMany(p.Annotations, database.WithoutCascadeDelete()),
 		database.HasMany(p.PersistentVolumeAnnotations, fk),
+		database.HasMany(p.Favorites, database.WithForeignKey("resource_uuid")),
 	}
 }

--- a/pkg/schema/v1/pod.go
+++ b/pkg/schema/v1/pod.go
@@ -53,6 +53,7 @@ type Pod struct {
 	ResourceAnnotations []ResourceAnnotation `db:"-"`
 	Pvcs                []PodPvc             `db:"-"`
 	Volumes             []PodVolume          `db:"-"`
+	Favorites           []Favorite           `db:"-"`
 	factory             *PodFactory
 }
 
@@ -459,6 +460,7 @@ func (p *Pod) Relations() []database.Relation {
 		database.HasMany(p.PodAnnotations, fk),
 		database.HasMany(p.Pvcs, fk),
 		database.HasMany(p.Volumes, fk),
+		database.HasMany(p.Favorites, database.WithForeignKey("resource_uuid")),
 	}
 }
 

--- a/pkg/schema/v1/pvc.go
+++ b/pkg/schema/v1/pvc.go
@@ -52,6 +52,7 @@ type Pvc struct {
 	Annotations         []Annotation         `db:"-"`
 	PvcAnnotations      []PvcAnnotation      `db:"-"`
 	ResourceAnnotations []ResourceAnnotation `db:"-"`
+	Favorites           []Favorite           `db:"-"`
 }
 
 type PvcCondition struct {
@@ -172,5 +173,6 @@ func (p *Pvc) Relations() []database.Relation {
 		database.HasMany(p.ResourceAnnotations, database.WithForeignKey("resource_uuid")),
 		database.HasMany(p.Annotations, database.WithoutCascadeDelete()),
 		database.HasMany(p.PvcAnnotations, fk),
+		database.HasMany(p.Favorites, database.WithForeignKey("resource_uuid")),
 	}
 }

--- a/pkg/schema/v1/replica_set.go
+++ b/pkg/schema/v1/replica_set.go
@@ -36,6 +36,7 @@ type ReplicaSet struct {
 	Annotations           []Annotation           `db:"-"`
 	ReplicaSetAnnotations []ReplicaSetAnnotation `db:"-"`
 	ResourceAnnotations   []ResourceAnnotation   `db:"-"`
+	Favorites             []Favorite             `db:"-"`
 }
 
 type ReplicaSetCondition struct {
@@ -217,5 +218,6 @@ func (r *ReplicaSet) Relations() []database.Relation {
 		database.HasMany(r.ResourceAnnotations, database.WithForeignKey("resource_uuid")),
 		database.HasMany(r.Annotations, database.WithoutCascadeDelete()),
 		database.HasMany(r.ReplicaSetAnnotations, fk),
+		database.HasMany(r.Favorites, database.WithForeignKey("resource_uuid")),
 	}
 }

--- a/pkg/schema/v1/service.go
+++ b/pkg/schema/v1/service.go
@@ -46,6 +46,7 @@ type Service struct {
 	ServiceAnnotations            []ServiceAnnotation  `db:"-"`
 	ResourceAnnotations           []ResourceAnnotation `db:"-"`
 	ServicePods                   []ServicePod         `db:"-"`
+	Favorites                     []Favorite           `db:"-"`
 	factory                       *ServiceFactory
 }
 
@@ -257,5 +258,6 @@ func (s *Service) Relations() []database.Relation {
 		database.HasMany(s.ServiceAnnotations, fk),
 		database.HasMany(s.ResourceAnnotations, fk),
 		database.HasMany(s.ServicePods, fk),
+		database.HasMany(s.Favorites, database.WithForeignKey("resource_uuid")),
 	}
 }

--- a/pkg/schema/v1/stateful_set.go
+++ b/pkg/schema/v1/stateful_set.go
@@ -42,6 +42,7 @@ type StatefulSet struct {
 	Annotations                                     []Annotation            `db:"-"`
 	StatefulSetAnnotations                          []StatefulSetAnnotation `db:"-"`
 	ResourceAnnotations                             []ResourceAnnotation    `db:"-"`
+	Favorites                                       []Favorite              `db:"-"`
 }
 
 type StatefulSetCondition struct {
@@ -234,5 +235,6 @@ func (s *StatefulSet) Relations() []database.Relation {
 		database.HasMany(s.ResourceAnnotations, database.WithForeignKey("resource_uuid")),
 		database.HasMany(s.Annotations, database.WithoutCascadeDelete()),
 		database.HasMany(s.StatefulSetAnnotations, fk),
+		database.HasMany(s.Favorites, database.WithForeignKey("resource_uuid")),
 	}
 }

--- a/schema/mysql/schema.sql
+++ b/schema/mysql/schema.sql
@@ -1011,8 +1011,10 @@ CREATE TABLE stateful_set_owner (
 
 CREATE TABLE favorite (
   resource_uuid binary(16) NOT NULL,
+  kind varchar(255) COLLATE utf8mb4_unicode_ci NOT NULL,
   username varchar(254) COLLATE utf8mb4_unicode_ci NOT NULL,
-  PRIMARY KEY (resource_uuid, username)
+  PRIMARY KEY (resource_uuid, username),
+  INDEX idx_favorite_username (username, kind) COMMENT 'Favorites filtered by username and kind'
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin;
 
 CREATE TABLE kubernetes_instance (

--- a/schema/mysql/schema.sql
+++ b/schema/mysql/schema.sql
@@ -1009,6 +1009,13 @@ CREATE TABLE stateful_set_owner (
   PRIMARY KEY (stateful_set_uuid, owner_uuid)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin;
 
+CREATE TABLE favorite (
+  resource_uuid binary(16) NOT NULL,
+  username varchar(255) NOT NULL,
+
+  PRIMARY KEY (resource_uuid, username)
+)ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin;
+
 CREATE TABLE kubernetes_instance (
   uuid binary(16) NOT NULL,
   cluster_uuid binary(16) NOT NULL,

--- a/schema/mysql/schema.sql
+++ b/schema/mysql/schema.sql
@@ -1011,7 +1011,7 @@ CREATE TABLE stateful_set_owner (
 
 CREATE TABLE favorite (
   resource_uuid binary(16) NOT NULL,
-  username varchar(255) NOT NULL,
+  username varchar(254) COLLATE utf8mb4_unicode_ci NOT NULL,
   PRIMARY KEY (resource_uuid, username)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin;
 

--- a/schema/mysql/schema.sql
+++ b/schema/mysql/schema.sql
@@ -1014,9 +1014,10 @@ CREATE TABLE favorite (
   kind varchar(255) COLLATE utf8mb4_unicode_ci NOT NULL,
   username varchar(254) COLLATE utf8mb4_unicode_ci NOT NULL,
   priority int unsigned,
-  PRIMARY KEY (resource_uuid, username),
-  INDEX idx_favorite_username (username, kind) COMMENT 'Favorites filtered by username and kind'
+  PRIMARY KEY (resource_uuid, username)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin;
+
+CREATE INDEX idx_favorite_username ON favorite(username, kind) COMMENT 'Favorites filtered by username and kind';
 
 CREATE TABLE kubernetes_instance (
   uuid binary(16) NOT NULL,

--- a/schema/mysql/schema.sql
+++ b/schema/mysql/schema.sql
@@ -1013,6 +1013,7 @@ CREATE TABLE favorite (
   resource_uuid binary(16) NOT NULL,
   kind varchar(255) COLLATE utf8mb4_unicode_ci NOT NULL,
   username varchar(254) COLLATE utf8mb4_unicode_ci NOT NULL,
+  priority int unsigned,
   PRIMARY KEY (resource_uuid, username),
   INDEX idx_favorite_username (username, kind) COMMENT 'Favorites filtered by username and kind'
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin;

--- a/schema/mysql/schema.sql
+++ b/schema/mysql/schema.sql
@@ -1012,9 +1012,8 @@ CREATE TABLE stateful_set_owner (
 CREATE TABLE favorite (
   resource_uuid binary(16) NOT NULL,
   username varchar(255) NOT NULL,
-
   PRIMARY KEY (resource_uuid, username)
-)ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin;
 
 CREATE TABLE kubernetes_instance (
   uuid binary(16) NOT NULL,


### PR DESCRIPTION
This PR introduces the ability to mark resources as favorites. Favorites are stored per user. Additionally to resource uuid and username the resource's kind is stored to optimize database queries. More information in the associated [PR in Icinga for Kubernetes Web](https://github.com/Icinga/icinga-kubernetes-web/pull/117#issue-2767206588).