### PR TITLE
Fix Prometheus config sync

### DIFF
--- a/internal/prometheus.go
+++ b/internal/prometheus.go
@@ -48,13 +48,13 @@ func SyncPrometheusConfig(ctx context.Context, db *database.DB, config *metrics.
 
 			stmt, _ := db.BuildUpsertStmt(schemav1.Config{})
 			if _, err := tx.NamedExecContext(ctx, stmt, toDb); err != nil {
-				return errors.Wrap(err, "cannot insert Prometheus config")
+				return errors.Wrap(err, "cannot upsert Prometheus config")
 			}
 
 			return nil
 		})
 		if err != nil {
-			return errors.Wrap(err, "cannot upsert Prometheus config")
+			return errors.Wrap(err, "transaction failed")
 		}
 	} else {
 		err := db.ExecTx(ctx, func(ctx context.Context, tx *sqlx.Tx) error {

--- a/internal/prometheus.go
+++ b/internal/prometheus.go
@@ -46,7 +46,7 @@ func SyncPrometheusConfig(ctx context.Context, db *database.DB, config *metrics.
 				return errors.Wrap(err, "cannot delete Prometheus config")
 			}
 
-			stmt, _ := db.BuildInsertStmt(schemav1.Config{})
+			stmt, _ := db.BuildUpsertStmt(schemav1.Config{})
 			if _, err := tx.NamedExecContext(ctx, stmt, toDb); err != nil {
 				return errors.Wrap(err, "cannot insert Prometheus config")
 			}


### PR DESCRIPTION
Use upsert statement instead of insert statement, so the non locked entries are overwritten.