### PR TITLE
Fix notifications config sync

### DIFF
--- a/internal/notifications.go
+++ b/internal/notifications.go
@@ -52,7 +52,7 @@ func SyncNotificationsConfig(ctx context.Context, db *database.DB, config *notif
 				return errors.Wrap(err, "cannot delete Icinga Notifications config")
 			}
 
-			stmt, _ := db.BuildInsertStmt(schemav1.Config{})
+			stmt, _ := db.BuildUpsertStmt(schemav1.Config{})
 			if _, err := tx.NamedExecContext(ctx, stmt, toDb); err != nil {
 				return errors.Wrap(err, "cannot insert Icinga Notifications config")
 			}

--- a/internal/notifications.go
+++ b/internal/notifications.go
@@ -54,13 +54,13 @@ func SyncNotificationsConfig(ctx context.Context, db *database.DB, config *notif
 
 			stmt, _ := db.BuildUpsertStmt(schemav1.Config{})
 			if _, err := tx.NamedExecContext(ctx, stmt, toDb); err != nil {
-				return errors.Wrap(err, "cannot insert Icinga Notifications config")
+				return errors.Wrap(err, "cannot upsert Icinga Notifications config")
 			}
 
 			return nil
 		})
 		if err != nil {
-			return errors.Wrap(err, "cannot upsert Icinga Notifications config")
+			return errors.Wrap(err, "transaction failed")
 		}
 	} else {
 		err := db.ExecTx(ctx, func(ctx context.Context, tx *sqlx.Tx) error {


### PR DESCRIPTION
Use upsert statement instead of insert statement, so the non locked entries are overwritten.