### PR TITLE
Fix panic in node role determination

### DIFF
--- a/pkg/schema/v1/node.go
+++ b/pkg/schema/v1/node.go
@@ -123,10 +123,13 @@ func (n *Node) Obtain(k8s kmetav1.Object, clusterUuid types.UUID) {
 	n.KubeProxyVersion = node.Status.NodeInfo.KubeProxyVersion
 
 	var roles []string
-	for labelName := range node.Labels {
+	for labelName, labelValue := range node.Labels {
 		if strings.Contains(labelName, "node-role") {
-			role := strings.SplitAfter(labelName, "/")[1]
-			roles = append(roles, role)
+			if _, role, ok := strings.Cut(labelName, "/"); ok {
+				roles = append(roles, role)
+			} else if labelValue != "" {
+				roles = append(roles, labelValue)
+			}
 		}
 	}
 	n.Roles = strings.Join(roles, ", ")


### PR DESCRIPTION
The previous implementation used `strings.SplitAfter` and accessed index [1] unconditionally, causing an index out of range panic for labels like "node-role: master" that don't contain a "/".

Use `strings.Cut` to safely extract the role from the label name when a "/" is present, and fall back to the label value otherwise. This correctly handles both `node-role.kubernetes.io/control-plane: ""`, `node-role.kubernetes.io/control-plane: true`, and `node-role: master` style labels.