### PR TITLE
Add Prometheus bearer token authentication

### DIFF
--- a/cmd/icinga-kubernetes/main.go
+++ b/cmd/icinga-kubernetes/main.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"flag"
 	"fmt"
+	"net/http"
 	"net/url"
 	"os"
 	"strings"
@@ -440,14 +441,21 @@ func main() {
 			basicAuthTransport.Insecure = true
 		}
 
+		var roundTripper http.RoundTripper = basicAuthTransport
 		if cfg.Prometheus.Username != "" {
 			basicAuthTransport.Username = cfg.Prometheus.Username
 			basicAuthTransport.Password = cfg.Prometheus.Password
+		} else if cfg.Prometheus.Token != "" || cfg.Prometheus.TokenFile != "" {
+			roundTripper = &kcom.BearerTokenTransport{
+				RoundTripper: basicAuthTransport,
+				Token:        cfg.Prometheus.Token,
+				TokenFile:    cfg.Prometheus.TokenFile,
+			}
 		}
 
 		promClient, err := promapi.NewClient(promapi.Config{
 			Address:      cfg.Prometheus.Url,
-			RoundTripper: basicAuthTransport,
+			RoundTripper: roundTripper,
 		})
 		if err != nil {
 			klog.Fatal(errors.Wrap(err, "error creating Prometheus client"))

--- a/config.example.yml
+++ b/config.example.yml
@@ -26,6 +26,15 @@ prometheus:
   # Prometheus server URL.
 #  url: http://localhost:9090
 
+  # Skip TLS/SSL certificate verification.
+#  insecure: false
+
+  # Bearer token for authenticating with Prometheus.
+#  token: token
+
+  # Path to a file containing the bearer token for authenticating with Prometheus.
+#  token_file: /var/run/secrets/kubernetes.io/serviceaccount/token
+
 # Configuration for Icinga Notifications daemon.
 notifications:
   # Icinga Notifications daemon URL.

--- a/doc/03-Configuration.md
+++ b/doc/03-Configuration.md
@@ -49,13 +49,17 @@ Defined in the `notifications` section of the configuration file.
 Connection configuration for a Prometheus instance that collects metrics from your Kubernetes cluster,
 from which Icinga for Kubernetes [synchronizes predefined metrics](01-About.md#metric-sync) to display charts in the UI.
 Defined in the `prometheus` section of the configuration file. If one of username or password is set, both must be set.
+Basic authentication and token authentication are mutually exclusive. If token authentication is used, only one of
+`token` or `token_file` may be set.
 
-| Option   | Description                                                                                                                |
-|----------|----------------------------------------------------------------------------------------------------------------------------|
-| url      | **Optional.** Prometheus server URL. If not set, metric synchronization is disabled.                                       |
-| insecure | **Optional.** Skip the TLS/SSL certificate verification. Can be set to 'true' or 'false'. If not set, defaults to 'false'. |
-| username | **Optional.** Prometheus username.                                                                                         |
-| password | **Optional.** Prometheus password.                                                                                         |
+| Option     | Description                                                                                                                |
+|------------|----------------------------------------------------------------------------------------------------------------------------|
+| url        | **Optional.** Prometheus server URL. If not set, metric synchronization is disabled.                                       |
+| insecure   | **Optional.** Skip the TLS/SSL certificate verification. Can be set to 'true' or 'false'. If not set, defaults to 'false'. |
+| username   | **Optional.** Prometheus username.                                                                                         |
+| password   | **Optional.** Prometheus password.                                                                                         |
+| token      | **Optional.** Bearer token for authenticating with Prometheus.                                                             |
+| token_file | **Optional.** Path to a file containing the bearer token for authenticating with Prometheus.                                |
 
 # Configuration via Environment Variables
 
@@ -93,12 +97,14 @@ The configurations set by environment variables override the ones set by YAML.
 
 ## Prometheus Configuration
 
-| Env                 | Description                                                                                                                |
-|---------------------|----------------------------------------------------------------------------------------------------------------------------|
-| PROMETHEUS_URL      | **Optional.** Prometheus server URL. If not set, metric synchronization is disabled.                                       |
-| PROMETHEUS_INSECURE | **Optional.** Skip the TLS/SSL certificate verification. Can be set to 'true' or 'false'. If not set, defaults to 'false'. |
-| PROMETHEUS_USERNAME | **Optional.** Prometheus username.                                                                                         |
-| PROMETHEUS_PASSWORD | **Optional.** Prometheus password.                                                                                         | |
+| Env                   | Description                                                                                                                |
+|-----------------------|----------------------------------------------------------------------------------------------------------------------------|
+| PROMETHEUS_URL        | **Optional.** Prometheus server URL. If not set, metric synchronization is disabled.                                       |
+| PROMETHEUS_INSECURE   | **Optional.** Skip the TLS/SSL certificate verification. Can be set to 'true' or 'false'. If not set, defaults to 'false'. |
+| PROMETHEUS_USERNAME   | **Optional.** Prometheus username.                                                                                         |
+| PROMETHEUS_PASSWORD   | **Optional.** Prometheus password.                                                                                         |
+| PROMETHEUS_TOKEN      | **Optional.** Bearer token for authenticating with Prometheus.                                                             |
+| PROMETHEUS_TOKEN_FILE | **Optional.** Path to a file containing the bearer token for authenticating with Prometheus.                                |
 
 ## Multi-Cluster Support using systemd Instantiated Services
 

--- a/internal/prometheus.go
+++ b/internal/prometheus.go
@@ -38,6 +38,19 @@ func SyncPrometheusConfig(ctx context.Context, db *database.DB, config *metrics.
 				schemav1.Config{ClusterUuid: clusterUuid, Key: schemav1.ConfigKeyPrometheusPassword, Value: config.Password, Locked: _true},
 			)
 		}
+		if config.Token != "" {
+			toDb = append(
+				toDb,
+				schemav1.Config{ClusterUuid: clusterUuid, Key: schemav1.ConfigKeyPrometheusToken, Value: config.Token, Locked: _true},
+			)
+		}
+
+		if config.TokenFile != "" {
+			toDb = append(
+				toDb,
+				schemav1.Config{ClusterUuid: clusterUuid, Key: schemav1.ConfigKeyPrometheusTokenFile, Value: config.TokenFile, Locked: _true},
+			)
+		}
 
 		err := db.ExecTx(ctx, func(ctx context.Context, tx *sqlx.Tx) error {
 			if _, err := tx.ExecContext(
@@ -98,6 +111,10 @@ func SyncPrometheusConfig(ctx context.Context, db *database.DB, config *metrics.
 					config.Username = r.Value
 				case schemav1.ConfigKeyPrometheusPassword:
 					config.Password = r.Value
+				case schemav1.ConfigKeyPrometheusToken:
+					config.Token = r.Value
+				case schemav1.ConfigKeyPrometheusTokenFile:
+					config.TokenFile = r.Value
 				}
 			}
 

--- a/pkg/com/bearer_token_transport.go
+++ b/pkg/com/bearer_token_transport.go
@@ -1,0 +1,38 @@
+package com
+
+import (
+	"net/http"
+	"os"
+	"strings"
+)
+
+// BearerTokenTransport is a http.RoundTripper that authenticates all requests using a bearer token.
+type BearerTokenTransport struct {
+	http.RoundTripper
+	Token     string
+	TokenFile string
+}
+
+// RoundTrip executes a single HTTP transaction with the bearer token.
+func (t *BearerTokenTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	token := t.Token
+	if token == "" && t.TokenFile != "" {
+		contents, err := os.ReadFile(t.TokenFile)
+		if err != nil {
+			return nil, err
+		}
+
+		token = strings.TrimSpace(string(contents))
+	}
+
+	if token != "" {
+		req.Header.Set("Authorization", "Bearer "+token)
+	}
+
+	rt := t.RoundTripper
+	if rt == nil {
+		rt = http.DefaultTransport
+	}
+
+	return rt.RoundTrip(req)
+}

--- a/pkg/metrics/config.go
+++ b/pkg/metrics/config.go
@@ -6,10 +6,12 @@ import (
 
 // PrometheusConfig defines Prometheus configuration.
 type PrometheusConfig struct {
-	Url      string `yaml:"url" env:"URL"`
-	Insecure string `yaml:"insecure" env:"INSECURE"`
-	Username string `yaml:"username" env:"USERNAME"`
-	Password string `yaml:"password" env:"PASSWORD"`
+	Url       string `yaml:"url" env:"URL"`
+	Insecure  string `yaml:"insecure" env:"INSECURE"`
+	Username  string `yaml:"username" env:"USERNAME"`
+	Password  string `yaml:"password" env:"PASSWORD"`
+	Token     string `yaml:"token" env:"TOKEN"`
+	TokenFile string `yaml:"token_file" env:"TOKEN_FILE"`
 }
 
 // Validate checks constraints in the supplied Prometheus configuration and returns an error if they are violated.
@@ -17,6 +19,14 @@ func (c *PrometheusConfig) Validate() error {
 	if c.Url != "" {
 		if (c.Username == "") != (c.Password == "") {
 			return errors.New("both username and password must be provided")
+		}
+
+		if c.Username != "" && (c.Token != "" || c.TokenFile != "") {
+			return errors.New("username/password and token authentication are mutually exclusive")
+		}
+
+		if c.Token != "" && c.TokenFile != "" {
+			return errors.New("only one of token or token_file must be provided")
 		}
 
 		if c.Insecure != "" && c.Insecure != "true" && c.Insecure != "false" {

--- a/pkg/schema/v1/config.go
+++ b/pkg/schema/v1/config.go
@@ -22,4 +22,6 @@ const (
 	ConfigKeyPrometheusInsecure            ConfigKey = "prometheus.insecure"
 	ConfigKeyPrometheusUsername            ConfigKey = "prometheus.username"
 	ConfigKeyPrometheusPassword            ConfigKey = "prometheus.password"
+	ConfigKeyPrometheusToken               ConfigKey = "prometheus.token"
+	ConfigKeyPrometheusTokenFile           ConfigKey = "prometheus.token_file"
 )

--- a/schema/mysql/schema.sql
+++ b/schema/mysql/schema.sql
@@ -1043,9 +1043,11 @@ CREATE TABLE config (
     'prometheus.url',
     'prometheus.insecure',
     'prometheus.username',
-    'prometheus.password'
+    'prometheus.password',
+    'prometheus.token',
+    'prometheus.token_file'
     ) COLLATE utf8mb4_unicode_ci NOT NULL,
-  value varchar(255) NOT NULL,
+  value text NOT NULL,
   locked enum('n', 'y') COLLATE utf8mb4_unicode_ci NOT NULL,
 
   PRIMARY KEY (`key`, cluster_uuid)


### PR DESCRIPTION
Adds support for authenticating against Prometheus with a bearer token or token file.

This keeps the existing basic auth support, but makes basic auth and bearer token auth mutually exclusive.
The daemon can now read `prometheus.token` or `prometheus.token_file`, persist locked Prometheus config values, and use them for Prometheus API requests. The web module adds the matching configuration fields.

Feature Request: #211 
