### PR TITLE
Improve Icinga Notifications source handling

### DIFF
--- a/pkg/notifications/client.go
+++ b/pkg/notifications/client.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"net/http"
 	"net/url"
+	"strings"
 	"sync"
 
 	"github.com/icinga/icinga-go-library/database"
@@ -65,7 +66,7 @@ func NewClient(name string, config Config, db *database.DB) (*Client, error) {
 }
 
 func (c *Client) ProcessEvent(ctx context.Context, event Event) error {
-	event.URL = c.webUrl.ResolveReference(event.URL)
+	event.URL = c.resolveEventURL(event.URL)
 	ev := event.Carry()
 
 	c.mu.Lock()
@@ -104,6 +105,24 @@ func (c *Client) ProcessEvent(ctx context.Context, event Event) error {
 	}
 
 	return errors.New("Received three rule updates from Icinga Notifications in a row")
+}
+
+func (c *Client) resolveEventURL(ref *url.URL) *url.URL {
+	if ref == nil || ref.IsAbs() {
+		return ref
+	}
+
+	base := *c.webUrl
+	if base.Path == "" {
+		base.Path = "/"
+	} else if !strings.HasSuffix(base.Path, "/") {
+		base.Path += "/"
+	}
+
+	eventURL := *ref
+	eventURL.Path = strings.TrimLeft(eventURL.Path, "/")
+
+	return base.ResolveReference(&eventURL)
 }
 
 // Stream consumes the items from the given `entities` chan and triggers a notifications event for each of them.

--- a/pkg/notifications/config.go
+++ b/pkg/notifications/config.go
@@ -1,9 +1,9 @@
 package notifications
 
 import (
-	"github.com/pkg/errors"
 	"net/url"
-	"regexp"
+
+	"github.com/pkg/errors"
 )
 
 type Config struct {
@@ -19,14 +19,6 @@ func (c *Config) Validate() error {
 	if c.Url != "" || c.Username != "" || c.Password != "" {
 		if c.Url == "" || c.Username == "" || c.Password == "" {
 			return errors.New("if one of 'url', 'username', or 'password' is set, all must be set")
-		}
-
-		usernameValid, err := regexp.MatchString(`^source-\d+$`, c.Username)
-		if err != nil {
-			return errors.WithStack(err)
-		}
-		if !usernameValid {
-			return errors.New("'username' must be of the form 'source-<source_id>'")
 		}
 
 		if _, err := url.Parse(c.Url); err != nil {


### PR DESCRIPTION
## Summary

Improve Icinga Notifications integration handling.

This fixes relative event URL resolution against the configured Icinga Web base URL and allows custom Icinga Notifications source usernames instead of requiring the generated `source-<id>` format.

## Changes

- Preserve the configured Icinga Web base path when resolving relative event URLs.
- Keep absolute event URLs unchanged.
- Remove the hard-coded `source-<id>` username validation.
- Keep the existing validation that URL, username, and password must be configured together.