### PR TITLE
reduce container memory

### DIFF
--- a/pkg/schema/v1/container.go
+++ b/pkg/schema/v1/container.go
@@ -15,16 +15,12 @@ import (
 	"k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/client-go/kubernetes"
 	"strings"
-	"sync"
 	"time"
 	"unicode/utf8"
 )
 
 var (
 	scheduler = gocron.NewScheduler(time.UTC)
-
-	containerLogs   = make(map[string]ContainerLog)
-	containerLogsMu sync.Mutex
 
 	deletedPodIds = make(map[string]bool)
 )
@@ -277,9 +273,15 @@ func (cl *ContainerLog) Upsert() interface{} {
 
 // syncContainerLogs fetches the logs from the kubernetes API for the given container and syncs to the database.
 func (cl *ContainerLog) syncContainerLogs(ctx context.Context, clientset *kubernetes.Clientset, db *database.Database) error {
+	current, err := cl.currentLog(ctx, db)
+	if err != nil {
+		return err
+	}
+	defer func() { cl.Logs = "" }()
+
 	logOptions := &kcorev1.PodLogOptions{Container: cl.ContainerName}
-	if !cl.LastUpdate.Time().IsZero() {
-		sinceSeconds := int64(time.Since(cl.LastUpdate.Time()).Seconds())
+	if !current.LastUpdate.Time().IsZero() {
+		sinceSeconds := int64(time.Since(current.LastUpdate.Time()).Seconds())
 		logOptions.SinceSeconds = &sinceSeconds
 	}
 
@@ -296,12 +298,30 @@ func (cl *ContainerLog) syncContainerLogs(ctx context.Context, clientset *kubern
 	}
 
 	cl.LastUpdate = types.UnixMilli(time.Now())
-	cl.Logs = truncate(cl.Logs+string(logs), MaxLogLength)
+	cl.Logs = truncate(current.Logs+string(logs), MaxLogLength)
 	entities := make(chan interface{}, 1)
 	entities <- cl
 	close(entities)
 
 	return db.UpsertStreamed(ctx, entities)
+}
+
+func (cl *ContainerLog) currentLog(ctx context.Context, db *database.Database) (ContainerLogMeta, error) {
+	var meta ContainerLogMeta
+	err := db.GetContext(
+		ctx,
+		&meta,
+		db.Rebind(`SELECT logs, last_update FROM container_log WHERE container_uuid = ?`),
+		cl.ContainerUuid,
+	)
+	if errors.Is(err, sql.ErrNoRows) {
+		return ContainerLogMeta{}, nil
+	}
+	if err != nil {
+		return ContainerLogMeta{}, database.CantPerformQuery(err, `SELECT logs, last_update FROM container_log WHERE container_uuid = ?`)
+	}
+
+	return meta, nil
 }
 
 func GetContainerState(container kcorev1.Container, status kcorev1.ContainerStatus) (IcingaState, string) {
@@ -459,13 +479,6 @@ func SyncContainers(ctx context.Context, db *database.Database, g *errgroup.Grou
 		Uuid    types.UUID
 		PodUuid types.UUID
 	}
-
-	// Fetch all container logs from the database
-	err := make(chan error, 1)
-	err <- warmup(ctx, db)
-	close(err)
-	com.ErrgroupReceive(g, err)
-
 	// Use buffered channel here not to block the goroutines, as they can stream container ids
 	// from multiple pods concurrently.
 	containerIds := make(chan interface{}, db.Options.MaxPlaceholdersPerStatement)
@@ -532,10 +545,6 @@ func SyncContainers(ctx context.Context, db *database.Database, g *errgroup.Grou
 							if err != nil && !errors.Is(err, gocron.ErrJobNotFoundWithTag) {
 								return err
 							}
-
-							containerLogsMu.Lock()
-							delete(containerLogs, container.Uuid.String())
-							containerLogsMu.Unlock()
 						}
 					}
 				})
@@ -563,12 +572,6 @@ func SyncContainers(ctx context.Context, db *database.Database, g *errgroup.Grou
 							PodName:       pod.Name,
 						}
 
-						containerLogsMu.Lock()
-						if cl, ok := containerLogs[container.Uuid.String()]; ok {
-							containerLog.Logs = truncate(cl.Logs, MaxLogLength)
-						}
-						containerLogsMu.Unlock()
-
 						scheduler.Every(ScheduleInterval.String()).Tag(container.Uuid.String())
 						_, err = scheduler.Do(containerLog.syncContainerLogs, ctx, pod.factory.clientset, db)
 						if err != nil {
@@ -579,10 +582,6 @@ func SyncContainers(ctx context.Context, db *database.Database, g *errgroup.Grou
 						if err != nil {
 							return err
 						}
-
-						containerLogsMu.Lock()
-						delete(containerLogs, container.Uuid.String())
-						containerLogsMu.Unlock()
 					}
 				}
 			}
@@ -590,42 +589,11 @@ func SyncContainers(ctx context.Context, db *database.Database, g *errgroup.Grou
 	})
 }
 
-// warmup fetches all container logs from the database and caches them in the containerlogs variable.
-func warmup(ctx context.Context, db *database.Database) error {
-	g, ctx := errgroup.WithContext(ctx)
-
-	entities, errs := db.YieldAll(ctx, func() (interface{}, error) {
-		return &ContainerLog{}, nil
-	}, db.BuildSelectStmt(ContainerLog{}, ContainerLog{}))
-	com.ErrgroupReceive(g, errs)
-
-	g.Go(func() error {
-		defer runtime.HandleCrash()
-
-		containerLogsMu.Lock()
-		defer containerLogsMu.Unlock()
-
-		for {
-			select {
-			case <-ctx.Done():
-				return ctx.Err()
-			case e, ok := <-entities:
-				if !ok {
-					return nil
-				}
-
-				containerLog := e.(*ContainerLog)
-				containerLogs[containerLog.ContainerUuid.String()] = *containerLog
-			}
-		}
-	})
-
-	return g.Wait()
-}
-
 // truncate truncates a UTF-8 string from the front to ensure it does not exceed the given byte length.
 // It also removes content before the first newline character if one is found in the truncated string.
 func truncate(s string, n int) string {
+	s = strings.ToValidUTF8(s, "")
+
 	if len(s) <= n {
 		return s
 	}

--- a/pkg/sync/v1/controller.go
+++ b/pkg/sync/v1/controller.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"fmt"
 	"github.com/go-logr/logr"
+	"github.com/icinga/icinga-go-library/types"
+	schemav1 "github.com/icinga/icinga-kubernetes/pkg/schema/v1"
 	"github.com/pkg/errors"
 	kmetav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/runtime"
@@ -31,11 +33,7 @@ func NewController(
 	}
 }
 
-func (c *Controller) Announce(obj interface{}) error {
-	return c.informer.GetStore().Add(obj)
-}
-
-func (c *Controller) Stream(ctx context.Context, sink *Sink) error {
+func (c *Controller) Stream(ctx context.Context, sink *Sink, warmupKeys map[string]types.UUID) error {
 	_, err := c.informer.AddEventHandler(NewEventHandler(c.queue, c.log.WithName("events")))
 	if err != nil {
 		return err
@@ -54,7 +52,35 @@ func (c *Controller) Stream(ctx context.Context, sink *Sink) error {
 		return errors.New("timed out waiting for caches to sync")
 	}
 
+	if err := c.enqueueMissingWarmupDeletes(warmupKeys); err != nil {
+		return err
+	}
+
 	return c.stream(ctx, sink)
+}
+
+func (c *Controller) enqueueMissingWarmupDeletes(warmupKeys map[string]types.UUID) error {
+	for key, warmupId := range warmupKeys {
+		item, exists, err := c.informer.GetStore().GetByKey(key)
+		if err != nil {
+			return errors.Wrapf(err, "fetching warmed-up key %s failed", key)
+		}
+
+		if exists {
+			currentId := schemav1.EnsureUUID(item.(kmetav1.Object).GetUID())
+			if currentId == warmupId {
+				continue
+			}
+		}
+
+		c.queue.Add(EventHandlerItem{
+			Type: EventDelete,
+			Id:   warmupId,
+			KKey: key,
+		})
+	}
+
+	return nil
 }
 
 func (c *Controller) stream(ctx context.Context, sink *Sink) error {

--- a/pkg/sync/v1/sync.go
+++ b/pkg/sync/v1/sync.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"github.com/go-logr/logr"
 	"github.com/icinga/icinga-go-library/com"
+	"github.com/icinga/icinga-go-library/types"
 	"github.com/icinga/icinga-kubernetes/pkg/cluster"
 	"github.com/icinga/icinga-kubernetes/pkg/database"
 	schemav1 "github.com/icinga/icinga-kubernetes/pkg/schema/v1"
@@ -37,21 +38,25 @@ func (s *Sync) Run(ctx context.Context, features ...Feature) error {
 	controller := NewController(s.informer, s.log.WithName("controller"))
 
 	with := NewFeatures(features...)
+	warmupKeys := map[string]types.UUID{}
 
 	if !with.NoWarmup() {
-		if err := s.warmup(ctx, controller); err != nil {
+		var err error
+		warmupKeys, err = s.warmup(ctx)
+		if err != nil {
 			return err
 		}
 	}
 
-	return s.sync(ctx, controller, features...)
+	return s.sync(ctx, controller, warmupKeys, features...)
 }
 
-func (s *Sync) warmup(ctx context.Context, c *Controller) error {
+func (s *Sync) warmup(ctx context.Context) (map[string]types.UUID, error) {
 	g, ctx := errgroup.WithContext(ctx)
 
 	meta := &schemav1.Meta{ClusterUuid: cluster.ClusterUuidFromContext(ctx)}
 	query := s.db.BuildSelectStmt(s.factory(), meta) + ` WHERE cluster_uuid=:cluster_uuid`
+	warmupKeys := make(map[string]types.UUID)
 
 	entities, errs := s.db.YieldAll(ctx, func() (interface{}, error) {
 		return s.factory(), nil
@@ -70,19 +75,23 @@ func (s *Sync) warmup(ctx context.Context, c *Controller) error {
 					return nil
 				}
 
-				if err := c.Announce(e); err != nil {
+				object := e.(schemav1.Resource)
+				key, err := cache.MetaNamespaceKeyFunc(object)
+				if err != nil {
 					return err
 				}
+
+				warmupKeys[key] = schemav1.EnsureUUID(object.GetUID())
 			case <-ctx.Done():
 				return ctx.Err()
 			}
 		}
 	})
 
-	return g.Wait()
+	return warmupKeys, g.Wait()
 }
 
-func (s *Sync) sync(ctx context.Context, c *Controller, features ...Feature) error {
+func (s *Sync) sync(ctx context.Context, c *Controller, warmupKeys map[string]types.UUID, features ...Feature) error {
 	sink := NewSink(func(i *Item) interface{} {
 		entity := s.factory()
 		entity.Obtain(*i.Item, cluster.ClusterUuidFromContext(ctx))
@@ -98,7 +107,7 @@ func (s *Sync) sync(ctx context.Context, c *Controller, features ...Feature) err
 	g.Go(func() error {
 		defer runtime.HandleCrash()
 
-		return c.Stream(ctx, sink)
+		return c.Stream(ctx, sink, warmupKeys)
 	})
 	g.Go(func() error {
 		defer runtime.HandleCrash()


### PR DESCRIPTION
## Summary

Reduce memory retention during synchronization and container log processing.

This change removes two sources of unnecessary retained state during startup and ongoing sync:

- container log contents are no longer warmed up globally and kept in scheduled job objects
- sync warmup no longer injects full database objects into the informer store

## Motivation

On large Kubernetes/OpenShift clusters, retaining previous database state in memory can grow significantly. Container logs can hold up to the configured maximum log length per container, and the generic sync warmup previously added complete database objects to the informer store before the real Kubernetes cache sync completed.

This can increase sustained heap usage during large-cluster operation and startup synchronization.

## Changes

- Remove the global container log warmup map and mutex.
- Load the current persisted container log only for the container currently being synchronized.
- Clear temporary container log contents after each sync job.
- Normalize log text with `strings.ToValidUTF8()` before truncating.
- Replace generic sync warmup object injection with key/UUID tracking.
- After the Kubernetes informer cache sync completes, enqueue deletes for warmed-up DB objects that are missing or have a different UID.

## Expected Impact

The daemon retains less historical synchronization state in memory. Container log memory is reduced from roughly all known/running containers times the maximum stored log length to only currently executing log sync jobs plus normal DB/Kubernetes client overhead.

The sync warmup also avoids keeping full DB objects in the informer store and instead tracks only keys and UUIDs needed to identify stale objects.