### PR TITLE
Fix `types.UUID` usages for future IGL compat

### DIFF
--- a/cmd/icinga-kubernetes/main.go
+++ b/cmd/icinga-kubernetes/main.go
@@ -328,7 +328,7 @@ func main() {
 			uuidMap := make(map[string][]types.UUID)
 			for _, inc := range incidents {
 				objectTagMap[inc.ObjectTags.UUID] = inc.ObjectTags
-				uuidMap[inc.ObjectTags.Resource] = append(uuidMap[inc.ObjectTags.Resource], types.UUID{UUID: uuid.MustParse(inc.ObjectTags.UUID)})
+				uuidMap[inc.ObjectTags.Resource] = append(uuidMap[inc.ObjectTags.Resource], types.MakeUUID(uuid.MustParse(inc.ObjectTags.UUID)))
 			}
 
 			ng, nctx := errgroup.WithContext(ctx)
@@ -371,11 +371,11 @@ func main() {
 					"namespace": tags.Namespace,
 				}
 				if tags.ClusterUUID != "" {
-					clusterUuid = types.UUID{UUID: uuid.MustParse(tags.ClusterUUID)}
+					clusterUuid = types.MakeUUID(uuid.MustParse(tags.ClusterUUID))
 					_tags["cluster_uuid"] = tags.ClusterUUID
 				}
 				ev := notifications.Event{
-					Uuid:        types.UUID{UUID: uuid.MustParse(tags.UUID)},
+					Uuid:        types.MakeUUID(uuid.MustParse(tags.UUID)),
 					ClusterUuid: clusterUuid,
 					Kind:        tags.Resource,
 					Name:        kcache.NewObjectName(tags.Namespace, tags.Name).String(),

--- a/pkg/schema/v1/contracts.go
+++ b/pkg/schema/v1/contracts.go
@@ -70,14 +70,14 @@ func (m *Meta) SetManagedFields([]kmetav1.ManagedFieldsEntry)  { panic("Not expe
 
 func EnsureUUID(uid ktypes.UID) types.UUID {
 	if id, err := uuid.Parse(string(uid)); err == nil {
-		return types.UUID{UUID: id}
+		return types.MakeUUID(id)
 	}
 
-	return types.UUID{UUID: uuid.NewSHA1(NameSpaceKubernetes, []byte(uid))}
+	return types.MakeUUID(uuid.NewSHA1(NameSpaceKubernetes, []byte(uid)))
 }
 
 func NewUUID(space types.UUID, data string) types.UUID {
-	return types.UUID{UUID: uuid.NewSHA1(space.UUID, []byte(data))}
+	return types.MakeUUID(uuid.NewSHA1(space.UUID, []byte(data)))
 }
 
 func NewNullableString(s any) sql.NullString {


### PR DESCRIPTION
This is a compat PR with future Icinga Go Library versions as we broke the the `types.UUID` usages with the following PR:

- https://github.com/Icinga/icinga-go-library/pull/235

This can't be merged yet though, since Icinga for Kuberentes has become incompatible with Icinga Go Library a long time ago as we changed all the notifications package and will require more change in here to be compatible with it.

I've used the following command to find and replace the `types.UUID` usages.
```
find . -type f -exec perl -pi -e 's{types.UUID\{UUID: (.*)\}}{types.MakeUUID(\1)}g' {} +
```
