### PR TITLE
Apply `go fix` suggestions

### DIFF
--- a/cmd/icinga-kubernetes/main.go
+++ b/cmd/icinga-kubernetes/main.go
@@ -218,7 +218,7 @@ func main() {
 	if !hasSchema {
 		dbLog.Info("Importing schema")
 
-		for _, ddl := range strings.Split(k8sMysql.Schema, ";") {
+		for ddl := range strings.SplitSeq(k8sMysql.Schema, ";") {
 			if ddl = strings.TrimSpace(ddl); ddl != "" {
 				if _, err := kdb.Exec(ddl); err != nil {
 					klog.Fatal(err)

--- a/internal/channel_multiplexer.go
+++ b/internal/channel_multiplexer.go
@@ -108,8 +108,6 @@ func (mux *channelMultiplexer[T]) Run(ctx context.Context) error {
 	defer close(sink)
 
 	for _, ch := range mux.in {
-		ch := ch
-
 		g.Go(func() error {
 			for {
 				select {

--- a/pkg/database/database.go
+++ b/pkg/database/database.go
@@ -330,8 +330,6 @@ func (db *Database) DeleteStreamed(
 		g, ctx = errgroup.WithContext(ctx)
 		streams := make(map[string]chan any, len(relations.Relations()))
 		for _, relation := range relations.Relations() {
-			relation := relation
-
 			if !relation.CascadeDelete() {
 				continue
 			}
@@ -448,8 +446,6 @@ func (db *Database) UpsertStreamed(
 		g, ctx = errgroup.WithContext(ctx)
 		streams := make(map[string]chan any, len(relations.Relations()))
 		for _, relation := range relations.Relations() {
-			relation := relation
-
 			ch := make(chan any)
 			g.Go(func() error {
 				defer runtime.HandleCrash()
@@ -503,7 +499,6 @@ func (db *Database) UpsertStreamed(
 					}
 
 					for _, relation := range entity.(HasRelations).Relations() {
-						relation := relation
 						g.Go(func() error {
 							defer runtime.HandleCrash()
 

--- a/pkg/database/database.go
+++ b/pkg/database/database.go
@@ -593,7 +593,7 @@ func (db *Database) query(ctx context.Context, query string, scope ...any) (rows
 func IsStruct(subject any) bool {
 	v := reflect.ValueOf(subject)
 	switch v.Kind() {
-	case reflect.Ptr:
+	case reflect.Pointer:
 		return v.Elem().Kind() == reflect.Struct
 	case reflect.Struct:
 		return true

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -340,8 +340,6 @@ func (pms *PromMetricSync) run(
 	g, ctx := errgroup.WithContext(ctx)
 
 	for _, promQuery := range promQueries {
-		promQuery := promQuery
-
 		g.Go(func() error {
 			var result model.Value
 			var warnings v1.Warnings

--- a/pkg/notifications/client.go
+++ b/pkg/notifications/client.go
@@ -71,7 +71,7 @@ func (c *Client) ProcessEvent(ctx context.Context, event Event) error {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 
-	for try := 0; try < 3; try++ {
+	for range 3 {
 		eventRuleIds, err := c.evaluateRulesForObject(
 			ctx,
 			event.Kind,

--- a/pkg/schema/v1/contracts.go
+++ b/pkg/schema/v1/contracts.go
@@ -107,7 +107,7 @@ func NewNullableString(s any) sql.NullString {
 			return sql.NullString{Valid: false, String: ""}
 		}
 
-		stringType := reflect.TypeOf("")
+		stringType := reflect.TypeFor[string]()
 		if v.Elem().CanConvert(stringType) {
 			v := v.Elem().Convert(stringType).Interface().(string)
 


### PR DESCRIPTION
Running `go fix` on all project files, this are the resulting changes.

Each commit swaps one construct for the form a later Go release introduced. The module currently declares `go 1.25.0` in `go.mod`, so all of them are available, and none changes behavior.