### PR TITLE
Sort imports

### DIFF
--- a/internal/cache/v1/multiplexers.go
+++ b/internal/cache/v1/multiplexers.go
@@ -2,6 +2,7 @@ package v1
 
 import (
 	"context"
+
 	"github.com/icinga/icinga-kubernetes/internal"
 	"golang.org/x/sync/errgroup"
 )

--- a/internal/channel_multiplexer.go
+++ b/internal/channel_multiplexer.go
@@ -2,8 +2,9 @@ package internal
 
 import (
 	"context"
-	"golang.org/x/sync/errgroup"
 	"sync/atomic"
+
+	"golang.org/x/sync/errgroup"
 )
 
 // ChannelMultiplexer is a multiplexer for channels of variable types.

--- a/internal/multiplex.go
+++ b/internal/multiplex.go
@@ -2,6 +2,7 @@ package internal
 
 import (
 	"context"
+
 	"golang.org/x/sync/errgroup"
 	"k8s.io/apimachinery/pkg/util/runtime"
 )

--- a/internal/notifications.go
+++ b/internal/notifications.go
@@ -3,6 +3,7 @@ package internal
 import (
 	"context"
 	"fmt"
+
 	"github.com/icinga/icinga-go-library/database"
 	"github.com/icinga/icinga-go-library/types"
 	"github.com/icinga/icinga-kubernetes/pkg/notifications"

--- a/internal/prometheus.go
+++ b/internal/prometheus.go
@@ -3,6 +3,8 @@ package internal
 import (
 	"context"
 	"fmt"
+	"strings"
+
 	"github.com/icinga/icinga-go-library/database"
 	"github.com/icinga/icinga-go-library/types"
 	"github.com/icinga/icinga-kubernetes/pkg/metrics"
@@ -13,7 +15,6 @@ import (
 	kmetav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
-	"strings"
 )
 
 func SyncPrometheusConfig(ctx context.Context, db *database.DB, config *metrics.PrometheusConfig, clusterUuid types.UUID) error {

--- a/pkg/cluster/cluster.go
+++ b/pkg/cluster/cluster.go
@@ -2,6 +2,7 @@ package cluster
 
 import (
 	"context"
+
 	"github.com/icinga/icinga-go-library/types"
 )
 

--- a/pkg/database/cleanup.go
+++ b/pkg/database/cleanup.go
@@ -3,12 +3,13 @@ package database
 import (
 	"context"
 	"fmt"
+	"time"
+
 	"github.com/icinga/icinga-go-library/backoff"
 	"github.com/icinga/icinga-go-library/com"
 	"github.com/icinga/icinga-go-library/periodic"
 	"github.com/icinga/icinga-go-library/retry"
 	"github.com/icinga/icinga-go-library/types"
-	"time"
 )
 
 // CleanupStmt defines information needed to compose cleanup statements.

--- a/pkg/database/driver.go
+++ b/pkg/database/driver.go
@@ -5,13 +5,14 @@ import (
 	"database/sql"
 	"database/sql/driver"
 	"fmt"
+	"time"
+
 	"github.com/go-logr/logr"
 	"github.com/go-sql-driver/mysql"
 	"github.com/icinga/icinga-go-library/backoff"
 	"github.com/icinga/icinga-go-library/retry"
 	"github.com/jmoiron/sqlx"
 	"github.com/pkg/errors"
-	"time"
 )
 
 const MySQL = "icinga-mysql"

--- a/pkg/database/pgsql_driver.go
+++ b/pkg/database/pgsql_driver.go
@@ -2,6 +2,7 @@ package database
 
 import (
 	"database/sql/driver"
+
 	"github.com/lib/pq"
 )
 

--- a/pkg/database/quoter.go
+++ b/pkg/database/quoter.go
@@ -2,8 +2,9 @@ package database
 
 import (
 	"fmt"
-	"github.com/jmoiron/sqlx"
 	"strings"
+
+	"github.com/jmoiron/sqlx"
 )
 
 type Quoter struct {

--- a/pkg/database/utils.go
+++ b/pkg/database/utils.go
@@ -3,13 +3,14 @@ package database
 import (
 	sqlDriver "database/sql/driver"
 	"fmt"
+	"net"
+	"strings"
+
 	"github.com/go-sql-driver/mysql"
 	"github.com/icinga/icinga-go-library/strcase"
 	"github.com/icinga/icinga-go-library/types"
 	"github.com/lib/pq"
 	"github.com/pkg/errors"
-	"net"
-	"strings"
 )
 
 // CantPerformQuery wraps the given error with the specified query that cannot be executed.

--- a/pkg/database/uuid.go
+++ b/pkg/database/uuid.go
@@ -3,6 +3,7 @@ package database
 import (
 	"database/sql/driver"
 	"encoding"
+
 	"github.com/google/uuid"
 )
 

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -3,6 +3,11 @@ package metrics
 import (
 	"context"
 	"fmt"
+	"net"
+	"strings"
+	"sync"
+	"time"
+
 	"github.com/icinga/icinga-go-library/backoff"
 	"github.com/icinga/icinga-go-library/database"
 	"github.com/icinga/icinga-go-library/logging"
@@ -17,10 +22,6 @@ import (
 	"golang.org/x/sync/errgroup"
 	kcorev1 "k8s.io/api/core/v1"
 	kcache "k8s.io/client-go/tools/cache"
-	"net"
-	"strings"
-	"sync"
-	"time"
 )
 
 // PromQuery defines a prometheus query with the metric group, the query and the name label

--- a/pkg/notifications/config.go
+++ b/pkg/notifications/config.go
@@ -1,9 +1,10 @@
 package notifications
 
 import (
-	"github.com/pkg/errors"
 	"net/url"
 	"regexp"
+
+	"github.com/pkg/errors"
 )
 
 type Config struct {

--- a/pkg/schema/v1/bitmask.go
+++ b/pkg/schema/v1/bitmask.go
@@ -3,8 +3,9 @@ package v1
 import (
 	"database/sql"
 	"database/sql/driver"
-	"golang.org/x/exp/constraints"
 	"strconv"
+
+	"golang.org/x/exp/constraints"
 )
 
 type Bitmask[T constraints.Integer] struct {

--- a/pkg/schema/v1/cluster.go
+++ b/pkg/schema/v1/cluster.go
@@ -2,6 +2,7 @@ package v1
 
 import (
 	"database/sql"
+
 	"github.com/icinga/icinga-go-library/types"
 )
 

--- a/pkg/schema/v1/config_map.go
+++ b/pkg/schema/v1/config_map.go
@@ -1,11 +1,12 @@
 package v1
 
 import (
+	"strings"
+
 	"github.com/icinga/icinga-go-library/types"
 	"github.com/icinga/icinga-kubernetes/pkg/database"
 	kcorev1 "k8s.io/api/core/v1"
 	kmetav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"strings"
 )
 
 type ConfigMap struct {

--- a/pkg/schema/v1/container.go
+++ b/pkg/schema/v1/container.go
@@ -5,19 +5,20 @@ import (
 	"database/sql"
 	"errors"
 	"fmt"
+	"io"
+	"strings"
+	"sync"
+	"time"
+	"unicode/utf8"
+
 	"github.com/go-co-op/gocron"
 	"github.com/icinga/icinga-go-library/com"
 	"github.com/icinga/icinga-go-library/types"
 	"github.com/icinga/icinga-kubernetes/pkg/database"
 	"golang.org/x/sync/errgroup"
-	"io"
 	kcorev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/client-go/kubernetes"
-	"strings"
-	"sync"
-	"time"
-	"unicode/utf8"
 )
 
 var (

--- a/pkg/schema/v1/contracts.go
+++ b/pkg/schema/v1/contracts.go
@@ -3,11 +3,12 @@ package v1
 import (
 	"database/sql"
 	"fmt"
+	"reflect"
+
 	"github.com/google/uuid"
 	"github.com/icinga/icinga-go-library/types"
 	kmetav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	ktypes "k8s.io/apimachinery/pkg/types"
-	"reflect"
 )
 
 var NameSpaceKubernetes = uuid.MustParse("3f249403-2bb0-428f-8e91-504d1fd7ddb6")

--- a/pkg/schema/v1/cron_job.go
+++ b/pkg/schema/v1/cron_job.go
@@ -3,6 +3,9 @@ package v1
 import (
 	"database/sql"
 	"fmt"
+	"strings"
+	"time"
+
 	"github.com/icinga/icinga-go-library/types"
 	"github.com/icinga/icinga-kubernetes/pkg/database"
 	kbatchv1 "k8s.io/api/batch/v1"
@@ -10,8 +13,6 @@ import (
 	kruntime "k8s.io/apimachinery/pkg/runtime"
 	kserializer "k8s.io/apimachinery/pkg/runtime/serializer"
 	kjson "k8s.io/apimachinery/pkg/runtime/serializer/json"
-	"strings"
-	"time"
 )
 
 type CronJob struct {

--- a/pkg/schema/v1/endpoint.go
+++ b/pkg/schema/v1/endpoint.go
@@ -2,13 +2,14 @@ package v1
 
 import (
 	"database/sql"
+	"strings"
+
 	"github.com/icinga/icinga-go-library/types"
 	"github.com/icinga/icinga-kubernetes/pkg/database"
 	v1 "k8s.io/api/core/v1"
 	kdiscoveryv1 "k8s.io/api/discovery/v1"
 	kmetav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	ktypes "k8s.io/apimachinery/pkg/types"
-	"strings"
 )
 
 type EndpointSlice struct {

--- a/pkg/schema/v1/event.go
+++ b/pkg/schema/v1/event.go
@@ -2,6 +2,7 @@ package v1
 
 import (
 	"database/sql"
+
 	"github.com/icinga/icinga-go-library/types"
 	keventsv1 "k8s.io/api/events/v1"
 	kmetav1 "k8s.io/apimachinery/pkg/apis/meta/v1"

--- a/pkg/schema/v1/ingress.go
+++ b/pkg/schema/v1/ingress.go
@@ -2,6 +2,8 @@ package v1
 
 import (
 	"database/sql"
+	"strings"
+
 	"github.com/icinga/icinga-go-library/types"
 	"github.com/icinga/icinga-kubernetes/pkg/database"
 	networkingv1 "k8s.io/api/networking/v1"
@@ -9,7 +11,6 @@ import (
 	kruntime "k8s.io/apimachinery/pkg/runtime"
 	kserializer "k8s.io/apimachinery/pkg/runtime/serializer"
 	kjson "k8s.io/apimachinery/pkg/runtime/serializer/json"
-	"strings"
 )
 
 type Ingress struct {

--- a/pkg/schema/v1/instance.go
+++ b/pkg/schema/v1/instance.go
@@ -2,6 +2,7 @@ package v1
 
 import (
 	"database/sql"
+
 	"github.com/icinga/icinga-go-library/types"
 )
 

--- a/pkg/schema/v1/job.go
+++ b/pkg/schema/v1/job.go
@@ -3,6 +3,8 @@ package v1
 import (
 	"database/sql"
 	"fmt"
+	"strings"
+
 	"github.com/icinga/icinga-go-library/strcase"
 	"github.com/icinga/icinga-go-library/types"
 	"github.com/icinga/icinga-kubernetes/pkg/database"
@@ -13,7 +15,6 @@ import (
 	kserializer "k8s.io/apimachinery/pkg/runtime/serializer"
 	kjson "k8s.io/apimachinery/pkg/runtime/serializer/json"
 	ktypes "k8s.io/apimachinery/pkg/types"
-	"strings"
 )
 
 type Job struct {

--- a/pkg/schema/v1/metric.go
+++ b/pkg/schema/v1/metric.go
@@ -1,9 +1,10 @@
 package v1
 
 import (
+	"strconv"
+
 	"github.com/icinga/icinga-go-library/database"
 	"github.com/icinga/icinga-go-library/types"
-	"strconv"
 )
 
 type PrometheusClusterMetric struct {

--- a/pkg/schema/v1/metrics.go
+++ b/pkg/schema/v1/metrics.go
@@ -1,8 +1,9 @@
 package v1
 
 import (
-	"github.com/icinga/icinga-go-library/types"
 	"time"
+
+	"github.com/icinga/icinga-go-library/types"
 )
 
 type PodMetrics struct {

--- a/pkg/schema/v1/namespace.go
+++ b/pkg/schema/v1/namespace.go
@@ -1,6 +1,8 @@
 package v1
 
 import (
+	"strings"
+
 	"github.com/icinga/icinga-go-library/types"
 	"github.com/icinga/icinga-kubernetes/pkg/database"
 	kcorev1 "k8s.io/api/core/v1"
@@ -8,7 +10,6 @@ import (
 	kruntime "k8s.io/apimachinery/pkg/runtime"
 	kserializer "k8s.io/apimachinery/pkg/runtime/serializer"
 	kjson "k8s.io/apimachinery/pkg/runtime/serializer/json"
-	"strings"
 )
 
 type Namespace struct {

--- a/pkg/schema/v1/persistent_volume.go
+++ b/pkg/schema/v1/persistent_volume.go
@@ -2,6 +2,8 @@ package v1
 
 import (
 	"database/sql"
+	"strings"
+
 	"github.com/icinga/icinga-go-library/types"
 	"github.com/icinga/icinga-kubernetes/pkg/database"
 	kcorev1 "k8s.io/api/core/v1"
@@ -10,7 +12,6 @@ import (
 	kserializer "k8s.io/apimachinery/pkg/runtime/serializer"
 	kjson "k8s.io/apimachinery/pkg/runtime/serializer/json"
 	ktypes "k8s.io/apimachinery/pkg/types"
-	"strings"
 )
 
 type PersistentVolume struct {

--- a/pkg/schema/v1/pvc.go
+++ b/pkg/schema/v1/pvc.go
@@ -2,6 +2,8 @@ package v1
 
 import (
 	"database/sql"
+	"strings"
+
 	"github.com/icinga/icinga-go-library/strcase"
 	"github.com/icinga/icinga-go-library/types"
 	"github.com/icinga/icinga-kubernetes/pkg/database"
@@ -10,7 +12,6 @@ import (
 	kruntime "k8s.io/apimachinery/pkg/runtime"
 	kserializer "k8s.io/apimachinery/pkg/runtime/serializer"
 	kjson "k8s.io/apimachinery/pkg/runtime/serializer/json"
-	"strings"
 )
 
 type kpersistentVolumeAccessModesSize byte

--- a/pkg/schema/v1/secret.go
+++ b/pkg/schema/v1/secret.go
@@ -1,11 +1,12 @@
 package v1
 
 import (
+	"strings"
+
 	"github.com/icinga/icinga-go-library/types"
 	"github.com/icinga/icinga-kubernetes/pkg/database"
 	kcorev1 "k8s.io/api/core/v1"
 	kmetav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"strings"
 )
 
 type Secret struct {

--- a/pkg/schema/v1/selector.go
+++ b/pkg/schema/v1/selector.go
@@ -1,8 +1,6 @@
 package v1
 
-import (
-	"github.com/icinga/icinga-go-library/types"
-)
+import "github.com/icinga/icinga-go-library/types"
 
 type Selector struct {
 	Uuid  types.UUID

--- a/pkg/schema/v1/service.go
+++ b/pkg/schema/v1/service.go
@@ -2,6 +2,8 @@ package v1
 
 import (
 	"database/sql"
+	"strings"
+
 	"github.com/icinga/icinga-go-library/strcase"
 	"github.com/icinga/icinga-go-library/types"
 	"github.com/icinga/icinga-kubernetes/pkg/database"
@@ -11,7 +13,6 @@ import (
 	kserializer "k8s.io/apimachinery/pkg/runtime/serializer"
 	kjson "k8s.io/apimachinery/pkg/runtime/serializer/json"
 	"k8s.io/client-go/kubernetes"
-	"strings"
 )
 
 type ServiceFactory struct {

--- a/pkg/schema/v1/utils.go
+++ b/pkg/schema/v1/utils.go
@@ -1,9 +1,10 @@
 package v1
 
 import (
+	"reflect"
+
 	"github.com/icinga/icinga-go-library/types"
 	"golang.org/x/exp/constraints"
-	"reflect"
 )
 
 func MarshalFirstNonNilStructFieldToJSON(i any) (string, string, error) {

--- a/pkg/sync/v1/controller.go
+++ b/pkg/sync/v1/controller.go
@@ -3,6 +3,7 @@ package v1
 import (
 	"context"
 	"fmt"
+
 	"github.com/go-logr/logr"
 	"github.com/pkg/errors"
 	kmetav1 "k8s.io/apimachinery/pkg/apis/meta/v1"

--- a/pkg/sync/v1/event_handler.go
+++ b/pkg/sync/v1/event_handler.go
@@ -2,6 +2,7 @@ package v1
 
 import (
 	"fmt"
+
 	"github.com/go-logr/logr"
 	"github.com/icinga/icinga-go-library/types"
 	schemav1 "github.com/icinga/icinga-kubernetes/pkg/schema/v1"

--- a/pkg/sync/v1/sync.go
+++ b/pkg/sync/v1/sync.go
@@ -2,6 +2,7 @@ package v1
 
 import (
 	"context"
+
 	"github.com/go-logr/logr"
 	"github.com/icinga/icinga-go-library/com"
 	"github.com/icinga/icinga-kubernetes/pkg/cluster"


### PR DESCRIPTION
Split the standard library imports into their own block in every file that mixed them with third-party ones, so the whole tree follows the layout some files already had.

Nothing outside the import blocks changes. The single import of `selector.go` loses its parentheses.