### PR TITLE
Clone request in `BasicAuthTransport.RoundTrip` before setting auth

### DIFF
--- a/pkg/com/basic_auth_transport.go
+++ b/pkg/com/basic_auth_transport.go
@@ -16,6 +16,8 @@ type BasicAuthTransport struct {
 // RoundTrip executes a single HTTP transaction with the basic auth credentials.
 func (t *BasicAuthTransport) RoundTrip(req *http.Request) (*http.Response, error) {
 	if t.Username != "" {
+		// RoundTrip must not modify the caller's request.
+		req = req.Clone(req.Context())
 		req.SetBasicAuth(t.Username, t.Password)
 	}
 


### PR DESCRIPTION
The `http.RoundTripper` documentation requires that `RoundTrip` does not modify the request, except for consuming and closing the request's body. Calling `SetBasicAuth` on the passed request broke that contract.

Cloning first keeps the header on the copy this round trip sends and leaves the caller's request untouched. A shallow struct copy is not enough, because `Header` is a map and the copy would share it with the original.