### PR TITLE
Move TLS configuration out of `BasicAuthTransport`

### DIFF
--- a/cmd/icinga-kubernetes/main.go
+++ b/cmd/icinga-kubernetes/main.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"flag"
 	"fmt"
+	"net/http"
 	"net/url"
 	"os"
 	"strings"
@@ -434,20 +435,19 @@ func main() {
 	}
 
 	if cfg.Prometheus.Url != "" {
-		basicAuthTransport := &kcom.BasicAuthTransport{}
-
-		if cfg.Prometheus.Insecure == "true" {
-			basicAuthTransport.Insecure = true
-		}
+		var transport http.RoundTripper = kcom.NewTransport(cfg.Prometheus.Insecure == "true")
 
 		if cfg.Prometheus.Username != "" {
-			basicAuthTransport.Username = cfg.Prometheus.Username
-			basicAuthTransport.Password = cfg.Prometheus.Password
+			transport = &kcom.BasicAuthTransport{
+				RoundTripper: transport,
+				Username:     cfg.Prometheus.Username,
+				Password:     cfg.Prometheus.Password,
+			}
 		}
 
 		promClient, err := promapi.NewClient(promapi.Config{
 			Address:      cfg.Prometheus.Url,
-			RoundTripper: basicAuthTransport,
+			RoundTripper: transport,
 		})
 		if err != nil {
 			klog.Fatal(errors.Wrap(err, "error creating Prometheus client"))

--- a/cmd/icinga-kubernetes/main.go
+++ b/cmd/icinga-kubernetes/main.go
@@ -438,11 +438,7 @@ func main() {
 		var transport http.RoundTripper = kcom.NewTransport(cfg.Prometheus.Insecure == "true")
 
 		if cfg.Prometheus.Username != "" {
-			transport = &kcom.BasicAuthTransport{
-				RoundTripper: transport,
-				Username:     cfg.Prometheus.Username,
-				Password:     cfg.Prometheus.Password,
-			}
+			transport = kcom.NewBasicAuthTransport(transport, cfg.Prometheus.Username, cfg.Prometheus.Password)
 		}
 
 		promClient, err := promapi.NewClient(promapi.Config{

--- a/pkg/com/basic_auth_transport.go
+++ b/pkg/com/basic_auth_transport.go
@@ -1,7 +1,6 @@
 package com
 
 import (
-	"crypto/tls"
 	"net/http"
 )
 
@@ -10,7 +9,6 @@ type BasicAuthTransport struct {
 	http.RoundTripper
 	Username string
 	Password string
-	Insecure bool
 }
 
 // RoundTrip executes a single HTTP transaction with the basic auth credentials.
@@ -24,15 +22,6 @@ func (t *BasicAuthTransport) RoundTrip(req *http.Request) (*http.Response, error
 	rt := t.RoundTripper
 	if rt == nil {
 		rt = http.DefaultTransport
-	}
-
-	if t.Insecure {
-		if transport, ok := rt.(*http.Transport); ok {
-			transportCopy := transport.Clone()
-			// #nosec G402 -- TLS certificate verification is intentionally configurable via YAML config.
-			transportCopy.TLSClientConfig = &tls.Config{InsecureSkipVerify: true}
-			rt = transportCopy
-		}
 	}
 
 	return rt.RoundTrip(req)

--- a/pkg/com/basic_auth_transport.go
+++ b/pkg/com/basic_auth_transport.go
@@ -4,25 +4,33 @@ import (
 	"net/http"
 )
 
-// BasicAuthTransport is a http.RoundTripper that authenticates all requests using HTTP Basic Authentication.
-type BasicAuthTransport struct {
-	http.RoundTripper
-	Username string
-	Password string
+// basicAuthTransport is an http.RoundTripper that authenticates all requests
+// using HTTP Basic Authentication.
+type basicAuthTransport struct {
+	transport http.RoundTripper
+	username  string
+	password  string
+}
+
+// NewBasicAuthTransport returns an http.RoundTripper that adds basic auth credentials
+// to every request before handing it to transport. It panics if transport is nil.
+func NewBasicAuthTransport(transport http.RoundTripper, username, password string) http.RoundTripper {
+	if transport == nil {
+		panic("NewBasicAuthTransport requires a non-nil transport")
+	}
+
+	return &basicAuthTransport{
+		transport: transport,
+		username:  username,
+		password:  password,
+	}
 }
 
 // RoundTrip executes a single HTTP transaction with the basic auth credentials.
-func (t *BasicAuthTransport) RoundTrip(req *http.Request) (*http.Response, error) {
-	if t.Username != "" {
-		// RoundTrip must not modify the caller's request.
-		req = req.Clone(req.Context())
-		req.SetBasicAuth(t.Username, t.Password)
-	}
+func (t *basicAuthTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	// RoundTrip must not modify the caller's request.
+	req = req.Clone(req.Context())
+	req.SetBasicAuth(t.username, t.password)
 
-	rt := t.RoundTripper
-	if rt == nil {
-		rt = http.DefaultTransport
-	}
-
-	return rt.RoundTrip(req)
+	return t.transport.RoundTrip(req)
 }

--- a/pkg/com/basic_auth_transport_test.go
+++ b/pkg/com/basic_auth_transport_test.go
@@ -1,0 +1,77 @@
+package com
+
+import (
+	"net/http"
+	"testing"
+)
+
+const (
+	testUsername = "user"
+	testPassword = "s3cret"
+)
+
+// recordingTransport captures the request it is handed and answers it without
+// a network round trip.
+type recordingTransport struct {
+	req *http.Request
+}
+
+func (t *recordingTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	t.req = req
+
+	return &http.Response{StatusCode: http.StatusOK, Body: http.NoBody, Request: req}, nil
+}
+
+func newRequest(t *testing.T) *http.Request {
+	t.Helper()
+
+	req, err := http.NewRequest(http.MethodGet, "https://example.com/api/v1/query", nil)
+	if err != nil {
+		t.Fatalf("cannot create request: %v", err)
+	}
+
+	return req
+}
+
+func TestBasicAuthTransportSetsCredentials(t *testing.T) {
+	inner := &recordingTransport{}
+	req := newRequest(t)
+
+	if _, err := NewBasicAuthTransport(inner, testUsername, testPassword).RoundTrip(req); err != nil {
+		t.Fatalf("got error %v, want none", err)
+	}
+
+	gotUsername, gotPassword, ok := inner.req.BasicAuth()
+	if !ok {
+		t.Fatal("got a request without basic auth credentials, want them set")
+	}
+
+	if gotUsername != testUsername || gotPassword != testPassword {
+		t.Errorf("got credentials %q:%q, want %q:%q", gotUsername, gotPassword, testUsername, testPassword)
+	}
+}
+
+// TestBasicAuthTransportDoesNotModifyRequest guards against credentials leaking
+// into a request the caller may reuse or inspect afterward.
+func TestBasicAuthTransportDoesNotModifyRequest(t *testing.T) {
+	inner := &recordingTransport{}
+	req := newRequest(t)
+
+	if _, err := NewBasicAuthTransport(inner, testUsername, testPassword).RoundTrip(req); err != nil {
+		t.Fatalf("got error %v, want none", err)
+	}
+
+	if got := req.Header.Get("Authorization"); got != "" {
+		t.Errorf("got Authorization %q on the caller's request, want it untouched", got)
+	}
+}
+
+func TestNewBasicAuthTransportRejectsNilTransport(t *testing.T) {
+	defer func() {
+		if recover() == nil {
+			t.Error("got no panic, want a panic for a nil transport")
+		}
+	}()
+
+	NewBasicAuthTransport(nil, testUsername, testPassword)
+}

--- a/pkg/com/transport.go
+++ b/pkg/com/transport.go
@@ -1,0 +1,19 @@
+package com
+
+import (
+	"crypto/tls"
+	"net/http"
+)
+
+// NewTransport returns an *http.Transport based on http.DefaultTransport.
+// TLS certificate verification is skipped if insecure is true.
+func NewTransport(insecure bool) *http.Transport {
+	transport := http.DefaultTransport.(*http.Transport).Clone()
+
+	if insecure {
+		// #nosec G402 -- TLS certificate verification is intentionally configurable via YAML config.
+		transport.TLSClientConfig = &tls.Config{InsecureSkipVerify: true}
+	}
+
+	return transport
+}

--- a/pkg/com/transport_test.go
+++ b/pkg/com/transport_test.go
@@ -1,0 +1,118 @@
+package com
+
+import (
+	"io"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+)
+
+// newTLSServer starts a TLS test server with a self-signed certificate.
+// connState may be nil. It must be set before the server starts, because the
+// serving goroutine reads it from then on.
+func newTLSServer(t *testing.T, connState func(net.Conn, http.ConnState)) *httptest.Server {
+	t.Helper()
+
+	server := httptest.NewUnstartedServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte("ok"))
+	}))
+	server.Config.ConnState = connState
+
+	server.StartTLS()
+	t.Cleanup(server.Close)
+
+	return server
+}
+
+// newCountingServer starts a TLS test server that counts the connections opened against it.
+func newCountingServer(t *testing.T) (*httptest.Server, *atomic.Int64) {
+	t.Helper()
+
+	var conns atomic.Int64
+
+	server := newTLSServer(t, func(_ net.Conn, state http.ConnState) {
+		if state == http.StateNew {
+			conns.Add(1)
+		}
+	})
+
+	return server, &conns
+}
+
+// doRequest performs a request and drains the body, which is what allows the connection to be reused.
+func doRequest(t *testing.T, client *http.Client, url string) error {
+	t.Helper()
+
+	resp, err := client.Get(url)
+	if err != nil {
+		return err
+	}
+
+	defer func() {
+		_ = resp.Body.Close()
+	}()
+
+	_, err = io.Copy(io.Discard, resp.Body)
+
+	return err
+}
+
+// TestNewTransportReusesConnections guards against configuring TLS per request instead of once.
+func TestNewTransportReusesConnections(t *testing.T) {
+	const requests = 10
+
+	tests := []struct {
+		name      string
+		transport func(http.RoundTripper) http.RoundTripper
+	}{
+		{
+			name: "plain",
+			transport: func(rt http.RoundTripper) http.RoundTripper {
+				return rt
+			},
+		},
+		{
+			name: "wrapped in BasicAuthTransport",
+			transport: func(rt http.RoundTripper) http.RoundTripper {
+				return &BasicAuthTransport{RoundTripper: rt, Username: "user", Password: "pass"}
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			server, conns := newCountingServer(t)
+			client := &http.Client{Transport: tc.transport(NewTransport(true))}
+
+			for i := range requests {
+				if err := doRequest(t, client, server.URL); err != nil {
+					t.Fatalf("request %d: %v", i, err)
+				}
+			}
+
+			if got := conns.Load(); got != 1 {
+				t.Errorf("got %d connections for %d requests, want 1", got, requests)
+			}
+		})
+	}
+}
+
+func TestNewTransportInsecureSkipsCertificateVerification(t *testing.T) {
+	server := newTLSServer(t, nil)
+	client := &http.Client{Transport: NewTransport(true)}
+
+	if err := doRequest(t, client, server.URL); err != nil {
+		t.Errorf("got error %v, want the self-signed certificate to be accepted", err)
+	}
+}
+
+func TestNewTransportVerifiesCertificateByDefault(t *testing.T) {
+	server := newTLSServer(t, nil)
+	client := &http.Client{Transport: NewTransport(false)}
+
+	if err := doRequest(t, client, server.URL); err == nil {
+		t.Error("got no error, want the self-signed certificate to be rejected")
+	}
+}

--- a/pkg/com/transport_test.go
+++ b/pkg/com/transport_test.go
@@ -74,9 +74,9 @@ func TestNewTransportReusesConnections(t *testing.T) {
 			},
 		},
 		{
-			name: "wrapped in BasicAuthTransport",
+			name: "wrapped in basicAuthTransport",
 			transport: func(rt http.RoundTripper) http.RoundTripper {
-				return &BasicAuthTransport{RoundTripper: rt, Username: "user", Password: "pass"}
+				return NewBasicAuthTransport(rt, "user", "pass")
 			},
 		},
 	}

--- a/pkg/notifications/client.go
+++ b/pkg/notifications/client.go
@@ -51,15 +51,15 @@ func NewClient(name string, config Config, db *database.DB) (*Client, error) {
 		rulesInfo: &source.RulesInfo{},
 		db:        db,
 		rawClient: http.Client{
-			Transport: &com.BasicAuthTransport{
-				RoundTripper: &ScopeTransport{
+			Transport: com.NewBasicAuthTransport(
+				&ScopeTransport{
 					RoundTripper: http.DefaultTransport,
 					BaseUrl:      baseUrl,
 					UserAgent:    name,
 				},
-				Username: config.Username,
-				Password: config.Password,
-			},
+				config.Username,
+				config.Password,
+			),
 		},
 	}, nil
 }


### PR DESCRIPTION
`BasicAuthTransport` mixed two unrelated concerns: it set basic auth credentials and it configured TLS. The TLS part was applied by cloning the inner transport inside `RoundTrip`, which runs once per request.

`http.Transport` owns the connection pool, and `Clone` deliberately returns a copy with an empty one. So every request built a fresh transport, found no idle connection, and paid a full TCP and TLS handshake. The connection it had just used became unreachable the moment `RoundTrip` returned, and stayed open until the idle timeout expired. With `insecure: true` the metric sync therefore re-handshaked on all 45 of its queries every 60 seconds.

`NewTransport` applies the TLS configuration once, at construction. Returning `*http.Transport` concretely also drops the old `if transport, ok := rt.(*http.Transport)` path, where a non-`*http.Transport` inner round tripper silently left certificate verification enabled despite `insecure: true`. What is left of the basic auth transport is only the credentials, decorating whatever transport it is handed.

The exported `BasicAuthTransport` struct's fields were independent, so you could build one with credentials and no transport, or a transport and no credentials. `NewBasicAuthTransport` takes all three at once, and unexporting the type leaves no other way to build one.

Two behaviors change with it. A nil transport now panics instead of falling back to `http.DefaultTransport`, because that fallback verifies certificates and would silently lose `insecure: true` for a caller who skipped `NewTransport`. And `RoundTrip` no longer skips authentication when the username is empty: callers already decide whether credentials apply, since the Prometheus path wraps only when a username is configured and both config validators reject a URL without credentials.